### PR TITLE
Add nutrition dashboard with PFC balance and target comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,32 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>カロリー計算アプリ</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <h1>カロリー計算</h1>
+
+    <div id="target-intake-settings">
+        <h2>目標摂取量設定</h2>
+        <div>
+            <label for="target-calories">目標カロリー (kcal):</label>
+            <input type="number" id="target-calories" placeholder="例: 2000" min="0">
+        </div>
+        <div>
+            <label for="target-protein">目標タンパク質 (g):</label>
+            <input type="number" id="target-protein" placeholder="例: 70" min="0">
+        </div>
+        <div>
+            <label for="target-lipid">目標脂質 (g):</label>
+            <input type="number" id="target-lipid" placeholder="例: 60" min="0">
+        </div>
+        <div>
+            <label for="target-carbohydrate">目標炭水化物 (g):</label>
+            <input type="number" id="target-carbohydrate" placeholder="例: 250" min="0">
+        </div>
+        <button id="save-targets-button">目標を保存/更新</button>
+    </div>
+    <hr>
 
     <div>
         <label for="food-item">食べ物:</label>
@@ -43,6 +66,18 @@
 
     <h2>合計カロリー</h2>
     <p id="total-calories">0 kcal</p>
+
+    <div id="nutrition-summary">
+        <h2>栄養バランス概要</h2>
+        <div>
+            <h3>摂取量 vs 目標量</h3>
+            <canvas id="intakeComparisonChart"></canvas>
+        </div>
+        <div>
+            <h3>PFCバランス</h3>
+            <canvas id="pfcBalanceChart"></canvas>
+        </div>
+    </div>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -8,10 +8,57 @@ document.addEventListener('DOMContentLoaded', () => {
     const foodList = document.getElementById('food-list');
     const totalCaloriesDisplay = document.getElementById('total-calories');
 
+    // Target intake elements
+    const targetCaloriesInput = document.getElementById('target-calories');
+    const targetProteinInput = document.getElementById('target-protein');
+    const targetLipidInput = document.getElementById('target-lipid');
+    const targetCarbohydrateInput = document.getElementById('target-carbohydrate');
+    const saveTargetsButton = document.getElementById('save-targets-button');
+
+    // Chart instances
+    let intakeChartInstance = null;
+    let pfcChartInstance = null;
+
     let items = [];
     let totalCalories = 0;
+    let totalProtein = 0;
+    let totalLipid = 0;
+    let totalCarbohydrate = 0;
+
+    // Global variables for target intake
+    let targetCalories = 0;
+    let targetProtein = 0;
+    let targetLipid = 0;
+    let targetCarbohydrate = 0;
 
     addButton.addEventListener('click', addItem);
+    saveTargetsButton.addEventListener('click', saveTargets);
+
+    function saveTargets() {
+        const tc = parseInt(targetCaloriesInput.value);
+        const tp = parseInt(targetProteinInput.value);
+        const tl = parseInt(targetLipidInput.value);
+        const tcarb = parseInt(targetCarbohydrateInput.value);
+
+        if (isNaN(tc) || tc < 0 ||
+            isNaN(tp) || tp < 0 ||
+            isNaN(tl) || tl < 0 ||
+            isNaN(tcarb) || tcarb < 0) {
+            alert('すべての目標値は有効な正の数値で入力してください。');
+            return;
+        }
+
+        targetCalories = tc;
+        targetProtein = tp;
+        targetLipid = tl;
+        targetCarbohydrate = tcarb;
+
+        alert('目標摂取量が保存されました！');
+        // Optionally, clear the input fields or update display elsewhere
+        // For now, we just store them in variables.
+        // console.log('Targets saved:', targetCalories, targetProtein, targetLipid, targetCarbohydrate);
+        updateCharts(); // Update charts when targets are saved
+    }
 
     function addItem() {
         const foodName = foodItemInput.value.trim();
@@ -38,7 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
         items.push(newItem);
 
         renderItems();
-        updateTotalCalories();
+        updateTotalIntake();
 
         foodItemInput.value = '';
         caloriesInput.value = '';
@@ -69,11 +116,109 @@ document.addEventListener('DOMContentLoaded', () => {
     function deleteItem(indexToDelete) {
         items.splice(indexToDelete, 1);
         renderItems();
-        updateTotalCalories();
+        updateTotalIntake();
     }
 
-    function updateTotalCalories() {
+    function updateTotalIntake() {
         totalCalories = items.reduce((sum, item) => sum + item.calories, 0);
+        totalProtein = items.reduce((sum, item) => sum + item.protein, 0);
+        totalLipid = items.reduce((sum, item) => sum + item.lipid, 0);
+        totalCarbohydrate = items.reduce((sum, item) => sum + item.carbohydrate, 0);
+
         totalCaloriesDisplay.textContent = `${totalCalories} kcal`;
+        // console.log('Totals updated:', totalCalories, totalProtein, totalLipid, totalCarbohydrate);
+        updateCharts(); // Update charts when total intake is updated
     }
+
+    function renderIntakeComparisonChart() {
+        const ctx = document.getElementById('intakeComparisonChart').getContext('2d');
+        if (intakeChartInstance) {
+            intakeChartInstance.destroy();
+        }
+        intakeChartInstance = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: ['カロリー (kcal)', 'タンパク質 (g)', '脂質 (g)', '炭水化物 (g)'],
+                datasets: [
+                    {
+                        label: '現在の摂取量',
+                        data: [totalCalories, totalProtein, totalLipid, totalCarbohydrate],
+                        backgroundColor: 'rgba(75, 192, 192, 0.5)',
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        borderWidth: 1
+                    },
+                    {
+                        label: '目標量',
+                        data: [targetCalories, targetProtein, targetLipid, targetCarbohydrate],
+                        backgroundColor: 'rgba(255, 99, 132, 0.5)',
+                        borderColor: 'rgba(255, 99, 132, 1)',
+                        borderWidth: 1
+                    }
+                ]
+            },
+            options: {
+                scales: { y: { beginAtZero: true } }
+            }
+        });
+    }
+
+    function renderPFCBalanceChart() {
+        const ctx = document.getElementById('pfcBalanceChart').getContext('2d');
+        const pfcData = calculatePFCBalance();
+        if (pfcChartInstance) {
+            pfcChartInstance.destroy();
+        }
+        pfcChartInstance = new Chart(ctx, {
+            type: 'pie',
+            data: {
+                labels: ['タンパク質 (%)', '脂質 (%)', '炭水化物 (%)'],
+                datasets: [{
+                    label: 'PFCバランス',
+                    data: [pfcData.protein, pfcData.lipid, pfcData.carbohydrate],
+                    backgroundColor: [
+                        'rgba(255, 159, 64, 0.7)',
+                        'rgba(255, 205, 86, 0.7)',
+                        'rgba(54, 162, 235, 0.7)'
+                    ],
+                    hoverOffset: 4
+                }]
+            }
+        });
+    }
+
+    function updateCharts() {
+        renderIntakeComparisonChart();
+        renderPFCBalanceChart();
+    }
+
+    function calculatePFCBalance() {
+        const caloriesPerProtein = 4;
+        const caloriesPerCarb = 4;
+        const caloriesPerLipid = 9;
+
+        const caloriesFromProtein = totalProtein * caloriesPerProtein;
+        const caloriesFromCarbs = totalCarbohydrate * caloriesPerCarb;
+        const caloriesFromLipid = totalLipid * caloriesPerLipid;
+
+        const totalMacroCalories = caloriesFromProtein + caloriesFromCarbs + caloriesFromLipid;
+
+        let proteinPercentage = 0;
+        let lipidPercentage = 0;
+        let carbPercentage = 0;
+
+        if (totalMacroCalories > 0) {
+            proteinPercentage = (caloriesFromProtein / totalMacroCalories) * 100;
+            lipidPercentage = (caloriesFromLipid / totalMacroCalories) * 100;
+            carbPercentage = (caloriesFromCarbs / totalMacroCalories) * 100;
+        }
+
+        return {
+            protein: proteinPercentage,
+            lipid: lipidPercentage,
+            carbohydrate: carbPercentage
+        };
+    }
+
+    // Initial chart rendering
+    updateCharts();
 });

--- a/test.html
+++ b/test.html
@@ -9,6 +9,7 @@
         .fail { color: red; }
         pre { background-color: #f0f0f0; padding: 10px; border: 1px solid #ccc; }
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <h1>カロリー計算アプリ - ユニットテスト</h1>
@@ -26,6 +27,17 @@
             <button id="add-button">追加</button>
             <ul id="food-list"></ul>
             <p id="total-calories">0 kcal</p>
+
+            <!-- Mock elements for target setting -->
+            <input type="number" id="target-calories">
+            <input type="number" id="target-protein">
+            <input type="number" id="target-lipid">
+            <input type="number" id="target-carbohydrate">
+            <button id="save-targets-button">目標を保存/更新</button>
+
+            <!-- Mock canvas elements for charts -->
+            <canvas id="intakeComparisonChart"></canvas>
+            <canvas id="pfcBalanceChart"></canvas>
         `;
     </script>
     <script src="script.js"></script>
@@ -249,6 +261,171 @@ ${error.stack}`;
             }
             return `Item with negative protein was added or alert not called. Items count: ${items.length}, Alert called: ${alertCalled}`;
         });
+
+        runTest("目標摂取量の設定と取得", () => {
+            const tcInput = document.getElementById('target-calories');
+            const tpInput = document.getElementById('target-protein');
+            const tlInput = document.getElementById('target-lipid');
+            const tcarbInput = document.getElementById('target-carbohydrate');
+            const saveButton = document.getElementById('save-targets-button');
+
+            // Store original alert and mock it
+            const originalAlert = window.alert;
+            let alertMessage = "";
+            window.alert = (msg) => { alertMessage = msg; console.log("Alert (mocked):", msg); };
+
+            // Set valid values
+            tcInput.value = "2000";
+            tpInput.value = "70";
+            tlInput.value = "60";
+            tcarbInput.value = "250";
+            saveButton.click();
+
+            // Directly access global variables from script.js (assuming they are exposed for testing or accessible in this scope)
+            // These are 'targetCalories', 'targetProtein', etc. defined in script.js
+            if (targetCalories !== 2000 || targetProtein !== 70 || targetLipid !== 60 || targetCarbohydrate !== 250) {
+                window.alert = originalAlert;
+                return "Valid target values not saved correctly. Found: TC=" + targetCalories + ", TP=" + targetProtein + ", TL=" + targetLipid + ", TCarb=" + targetCarbohydrate;
+            }
+            if (alertMessage !== "目標摂取量が保存されました！") {
+                 window.alert = originalAlert;
+                 return "Success alert not shown for valid targets. Alert: " + alertMessage;
+            }
+
+            // Test invalid input (negative value)
+            alertMessage = ""; // Reset alert message
+            tpInput.value = "-10"; // Invalid protein
+            saveButton.click();
+
+            if (targetProtein === -10) { // Should not update to invalid
+                window.alert = originalAlert;
+                return "Target protein updated to invalid value -10.";
+            }
+            if (targetProtein !== 70) { // Should retain previous valid value
+                window.alert = originalAlert;
+                return "Target protein did not retain its previous valid value. Found: " + targetProtein;
+            }
+             if (alertMessage !== "すべての目標値は有効な正の数値で入力してください。") {
+                window.alert = originalAlert;
+                return "Validation alert for negative target not shown correctly. Alert: " + alertMessage;
+            }
+
+            window.alert = originalAlert; // Restore original alert
+            return true;
+        });
+
+        runTest("複数操作後の総主要栄養素計算の検証", () => {
+            items = []; // Reset items
+            const foodItemInput = document.getElementById('food-item');
+            const caloriesInput = document.getElementById('calories');
+            const proteinInput = document.getElementById('protein');
+            const lipidInput = document.getElementById('lipid');
+            const carbohydrateInput = document.getElementById('carbohydrate');
+            const addButton = document.getElementById('add-button');
+
+            // Add item 1
+            foodItemInput.value = "チキン"; proteinInput.value = "30"; lipidInput.value = "10"; carbohydrateInput.value = "0"; caloriesInput.value = "200";
+            addButton.click();
+            // Add item 2
+            foodItemInput.value = "ライス"; proteinInput.value = "5"; lipidInput.value = "1"; carbohydrateInput.value = "40"; caloriesInput.value = "200";
+            addButton.click();
+
+            // Directly access global total variables from script.js
+            // These are 'totalProtein', 'totalLipid', 'totalCarbohydrate'
+            if (totalProtein !== 35 || totalLipid !== 11 || totalCarbohydrate !== 40) {
+                return `Total macronutrients incorrect. Expected P:35, L:11, C:40. Found P:${totalProtein}, L:${totalLipid}, C:${totalCarbohydrate}`;
+            }
+            return true;
+        });
+
+        runTest("PFCバランス計算の検証 (calculatePFCBalance)", () => {
+            // Manually set global total nutrient values (assuming they are accessible)
+            totalProtein = 50; // 200 kcal
+            totalLipid = 20;   // 180 kcal
+            totalCarbohydrate = 100; // 400 kcal
+            // Total macro calories = 200 + 180 + 400 = 780 kcal
+
+            const pfc = calculatePFCBalance(); // Assuming calculatePFCBalance is accessible
+
+            const expectedP = (200 / 780) * 100;
+            const expectedL = (180 / 780) * 100;
+            const expectedC = (400 / 780) * 100;
+
+            // Check with a tolerance for floating point comparisons
+            if (Math.abs(pfc.protein - expectedP) > 0.01 ||
+                Math.abs(pfc.lipid - expectedL) > 0.01 ||
+                Math.abs(pfc.carbohydrate - expectedC) > 0.01) {
+                return `PFC calculation incorrect. Expected P:${expectedP.toFixed(2)} L:${expectedL.toFixed(2)} C:${expectedC.toFixed(2)}. Found P:${pfc.protein.toFixed(2)} L:${pfc.lipid.toFixed(2)} C:${pfc.carbohydrate.toFixed(2)}`;
+            }
+
+            // Test edge case: zero macronutrients
+            totalProtein = 0; totalLipid = 0; totalCarbohydrate = 0;
+            const pfcZero = calculatePFCBalance();
+            if (pfcZero.protein !== 0 || pfcZero.lipid !== 0 || pfcZero.carbohydrate !== 0) {
+                return `PFC calculation for zero macros incorrect. Expected all 0. Found P:${pfcZero.protein} L:${pfcZero.lipid} C:${pfcZero.carbohydrate}`;
+            }
+            return true;
+        });
+        
+        runTest("チャート更新関数 (updateCharts) の呼び出し検証", () => {
+            let updateChartsCalled = false;
+            const originalUpdateCharts = window.updateCharts; // Assuming updateCharts is exposed on window for testing
+
+            // Spy on updateCharts
+            window.updateCharts = () => {
+                updateChartsCalled = true;
+                if (originalUpdateCharts) originalUpdateCharts(); // Call original if it exists and you want charts to actually render
+            };
+
+            // Test after addItem
+            updateChartsCalled = false;
+            document.getElementById('food-item').value = "Test chart food";
+            document.getElementById('calories').value = "10";
+            document.getElementById('protein').value = "1";
+            document.getElementById('lipid').value = "1";
+            document.getElementById('carbohydrate').value = "1";
+            document.getElementById('add-button').click();
+            if (!updateChartsCalled) {
+                window.updateCharts = originalUpdateCharts;
+                return "updateCharts not called after addItem";
+            }
+
+            // Test after deleteItem (requires an item to be present)
+            updateChartsCalled = false;
+            if (items.length > 0) {
+                const foodList = document.getElementById('food-list');
+                if (foodList.children.length > 0 && foodList.children[0].querySelector('button')) {
+                     foodList.children[0].querySelector('button').click(); // Click delete on the first item
+                     if (!updateChartsCalled) {
+                         window.updateCharts = originalUpdateCharts;
+                         return "updateCharts not called after deleteItem";
+                     }
+                } else {
+                    console.warn("Skipping deleteItem chart call test: no item or delete button found.");
+                }
+            } else {
+                 console.warn("Skipping deleteItem chart call test: no items to delete.");
+            }
+
+
+            // Test after saveTargets
+            updateChartsCalled = false;
+            document.getElementById('target-calories').value = "2100";
+            document.getElementById('save-targets-button').click();
+             const originalAlert = window.alert; // Mock alert for this part
+             window.alert = () => {};
+            if (!updateChartsCalled) {
+                window.updateCharts = originalUpdateCharts;
+                window.alert = originalAlert;
+                return "updateCharts not called after saveTargets";
+            }
+            window.alert = originalAlert;
+
+
+            window.updateCharts = originalUpdateCharts; // Restore original function
+            return true;
+        });
+
 
         // Summary
         const summaryDiv = document.createElement('h3');


### PR DESCRIPTION
This commit introduces a nutrition dashboard that includes:
- Target intake setting: You can set your target daily intake for calories, protein, lipids, and carbohydrates.
- PFC balance calculation: The application now calculates and displays the percentage of calories derived from protein, fat, and carbohydrates.
- Graphical visualization:
    - A bar chart compares current total intake of calories and macronutrients against the set targets.
    - A pie chart displays the PFC balance of the current intake.
- Chart.js library was integrated for rendering these visualizations.
- All functionalities are updated with corresponding unit tests.