### PR TITLE
feat: Add AI menu suggestion feature via backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - `style.css`: アプリケーションのスタイリング用CSSファイル
 - `script.js`: アプリケーションの動作ロジックを記述したJavaScriptファイル
 - `test.html`: JavaScriptのロジックをテストするためのユニットテストファイル
+- `app.py`: Python Flask backend server
+- `requirements.txt`: Python dependencies
 
 ## 使用方法
 
@@ -35,3 +37,27 @@
 - HTML
 - CSS
 - JavaScript (ES6)
+- Python (Flask)
+- Google Gemini API
+
+## Backend Setup and Usage
+
+### 1. Install Dependencies
+Install the required Python packages using pip:
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Set API Key
+Set your Gemini API key as an environment variable named `GEMINI_API_KEY`. For example, in bash:
+```bash
+export GEMINI_API_KEY='YOUR_API_KEY'
+```
+Replace `YOUR_API_KEY` with your actual Gemini API key.
+
+### 3. Run the Backend Server
+Run the Flask backend server using:
+```bash
+python app.py
+```
+The server will start by default on `http://127.0.0.1:5000`. The frontend application expects to communicate with the backend at the `/api/getMenuSuggestions` endpoint (i.e., `http://127.0.0.1:5000/api/getMenuSuggestions`).

--- a/app.py
+++ b/app.py
@@ -1,0 +1,70 @@
+from flask import Flask, request, jsonify
+import os
+import google.generativeai as genai
+
+app = Flask(__name__)
+
+# Retrieve Gemini API key from environment variable
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+@app.route('/api/getMenuSuggestions', methods=['POST'])
+def get_menu_suggestions():
+    if not GEMINI_API_KEY:
+        return jsonify({"error": "API key not configured"}), 500
+
+    data = request.get_json()
+    if not data or 'currentIntake' not in data or 'targetIntake' not in data:
+        return jsonify({"error": "Missing data"}), 400
+
+    current_intake = data['currentIntake']
+    target_intake = data['targetIntake']
+
+    # Construct the prompt for Gemini API
+    prompt = f"""
+Current intake:
+Calories: {current_intake.get('calories', 0)}
+Protein: {current_intake.get('protein', 0)}g
+Fat: {current_intake.get('fat', 0)}g
+Carbohydrates: {current_intake.get('carbohydrates', 0)}g
+
+Target intake:
+Calories: {target_intake.get('calories', 0)}
+Protein: {target_intake.get('protein', 0)}g
+Fat: {target_intake.get('fat', 0)}g
+Carbohydrates: {target_intake.get('carbohydrates', 0)}g
+
+Based on the current and target intake values, please provide 2-3 specific meal or food suggestions to help meet the targets.
+Please provide the response as a list of suggestions, for example:
+1. Grilled Chicken Salad
+2. Lentil Soup
+"""
+
+    try:
+        genai.configure(api_key=GEMINI_API_KEY)
+        model = genai.GenerativeModel('gemini-pro')
+        response = model.generate_content(prompt)
+
+        if response.text:
+            suggestions_text = response.text
+            # Split by newline
+            raw_suggestions = suggestions_text.splitlines()
+            parsed_suggestions = []
+            for line in raw_suggestions:
+                # Remove common list prefixes (e.g., "1. ", "- ", "* ")
+                cleaned_line = line.lstrip('0123456789.-* ')
+                # Add to list if not empty after cleaning
+                if cleaned_line:
+                    parsed_suggestions.append(cleaned_line)
+
+            if parsed_suggestions:
+                return jsonify({"suggestions": parsed_suggestions})
+            else:
+                # Fallback if parsing results in an empty list but there was text
+                return jsonify({"suggestions": ["Could not parse suggestions from AI.", suggestions_text]})
+        else:
+            return jsonify({"error": "Empty response from Gemini API"}), 500
+    except Exception as e:
+        return jsonify({"error": f"Error calling Gemini API: {str(e)}"}), 500
+
+if __name__ == '__main__':
+    app.run(port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+google-generativeai


### PR DESCRIPTION
I've implemented a Python Flask backend to provide AI-powered menu suggestions.

The backend exposes a `/api/getMenuSuggestions` endpoint for the frontend to call. This endpoint takes your current and target nutritional intake as input, constructs a prompt for the Google Gemini API, calls the API, parses the response, and returns a list of menu suggestions.

The Gemini API key is securely handled on the backend and read from the `GEMINI_API_KEY` environment variable.

New files:
- `app.py`: The Flask application with the API logic.
- `requirements.txt`: Python dependencies (Flask, google-generativeai).

Updated files:
- `README.md`: Added instructions for setting up and running the backend.

Output: